### PR TITLE
New interactions for summoned guards

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -554,12 +554,18 @@ NameGuard,Guard
 KillGuard,"The guard passes out and drops her possessions!"
 AttackGuardLock,"The guard locks your restraints!"
 AttackGuardBind,"The guard places some cuffs on you!"
+AttackGuardAddRestraints,"The guard places a NewRestraintName on you"
+AttackGuardChangeRestraints,"The guard replaces your OldRestraintName with a NewRestraintName"
+AttackGuardRemoveRestraints,"The guard removes your OldRestraintName"
 AttackGuard,"The guard plays with you, groping and rubbing your body!"
 
 NameGuardHeavy,Armed Guard
 KillGuardHeavy,"The armed guard retreats, but drops a keyring!"
 AttackGuardHeavyLock,"The guard locks your restraints!"
 AttackGuardHeavyBind,"The guard shocks you and slaps on some cuffs!"
+AttackGuardHeavyAddRestraints,"The guard places a NewRestraintName on you"
+AttackGuardHeavyChangeRestraints,"The guard replaces your OldRestraintName with a NewRestraintName"
+AttackGuardHeavyRemoveRestraints,"The guard removes your OldRestraintName"
 AttackGuardHeavy,"The guard electrocutes you with her taser!!!"
 AttackGuardHeavyStun,"The guard electrocutes you with her taser!!!"
 


### PR DESCRIPTION
Added two new behaviors to summoned jail guards: restraint swapping and teasing

- Teasing has between a 5% and a 45% chance to be selected when the guard idles, the percentage grows with the security level
- A teasing guard will approach the player, then (if possible) proceed to use the remote on her with a random charge between 2 and 22, with the upper value (22) depending of the security level. The remote allows for overcharging, so the guard might apply several charges during her teasing phase.
- If the guard can't use the remote due to lack of appropriate items on the player, she will proceed to use her normal attack instead. This is limited to non-combat attacks, so for the Heavy Guard will "fail" the teasing action as her attack is of type Electric (that seemed like an unwanted thing for her to apply to the player on a random basis).
- Restraint swapping is always considered when the guard idles and hasn't already picked the teasing behavior.
- Restraint swapping works by selecting a random body slot, then checking the applicabilty of the swap.
- If a prison restraint is available for this slot at this security level and is not already applied, the guard will proceed to apply / replace it. The eventual old restraint is not added to the player's inventory.
- If no prison restraint is available for this slot at this level, but the current applied restraint is a prison restraint that requires a bigger security level, then the guard removes the existing restraint. The old restraint is not added to the player's inventory.