### PR TITLE
Add 'leash touring" interaction for guards

### DIFF
--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
@@ -1282,12 +1282,7 @@ function KinkyDungeonUpdateEnemies(delta) {
 						if (player.player && playerDist < range + 0.5 && (((!enemy.Enemy.noLeashUnlessExhausted || !KinkyDungeonHasStamina(1.1)) && enemy.Enemy.tags && enemy.Enemy.tags.has("leashing")) || attack.includes("Pull")) && (KinkyDungeonLeashedPlayer < 1 || KinkyDungeonLeashingEnemy == enemy)) {
 							let wearingLeash = false;
 							if (!wearingLeash && !attack.includes("Pull"))
-								for (let restraint of KinkyDungeonRestraintList()) {
-									if (restraint.restraint && restraint.restraint.leash) {
-										wearingLeash = true;
-										break;
-									}
-								}
+								wearingLeash = KinkyDungeonIsWearingLeash();
 							let leashToExit = enemy.Enemy.tags.has("leashing") && !KinkyDungeonHasStamina(1.1) && playerDist < 1.5;
 							let leashed = wearingLeash || attack.includes("Pull");
 							if (leashed) {

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
@@ -1828,6 +1828,8 @@ function KinkyDungeonHandleJailSpawns() {
 						KinkyDungeonSendTextMessage(5, TextGet("Attack" + KinkyDungeonJailGuard.Enemy.name), "yellow", 1);
 					}
 					KinkyDungeonJailGuard.CurrentAction = "jailWander";
+					KinkyDungeonJailGuard.gx = KinkyDungeonJailGuard.x;
+					KinkyDungeonJailGuard.gy = KinkyDungeonJailGuard.y;
 				}
 
 				if (KinkyDungeonJailGuard.CurrentAction === "jailAddRestraints") {
@@ -1842,6 +1844,8 @@ function KinkyDungeonHandleJailSpawns() {
 						KinkyDungeonSendTextMessage(5, msg, "yellow", 1);
 					}
 					KinkyDungeonJailGuard.CurrentAction = "jailWander";
+					KinkyDungeonJailGuard.gx = KinkyDungeonJailGuard.x;
+					KinkyDungeonJailGuard.gy = KinkyDungeonJailGuard.y;
 				}
 
 				if (KinkyDungeonJailGuard.CurrentAction === "jailRemoveRestraints") {
@@ -1853,10 +1857,12 @@ function KinkyDungeonHandleJailSpawns() {
 						KinkyDungeonSendTextMessage(5, msg, "yellow", 1);
 					}
 					KinkyDungeonJailGuard.CurrentAction = "jailWander";
+					KinkyDungeonJailGuard.gx = KinkyDungeonJailGuard.x;
+					KinkyDungeonJailGuard.gy = KinkyDungeonJailGuard.y;
 				}
 
 			} else {
-				KinkyDungeonJailGuard.gx = KinkyDungeonPlayerEntity.x + 1;
+				KinkyDungeonJailGuard.gx = KinkyDungeonPlayerEntity.x;
 				KinkyDungeonJailGuard.gy = KinkyDungeonPlayerEntity.y;
 			}
 		}

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonEnemies.js
@@ -1634,6 +1634,7 @@ let KinkyDungeonGuardSpawnTimerMax = 74;
 let KinkyDungeonGuardSpawnTimerMin = 52;
 let KinkyDungeonMaxPrisonReduction = 10;
 let KinkyDungeonPrisonReduction = 0;
+let KinkyDungeonPrisonExtraGhostRep = 0;
 
 let KinkyDungeonEnemyID = 0;
 
@@ -1821,6 +1822,7 @@ function KinkyDungeonHandleJailSpawns() {
 					msg = msg.replace("OldRestraintName", TextGet("Restraint"+leashItemToRemove.restraint.name));
 					KinkyDungeonSendTextMessage(5, msg, "yellow", 1);
 				}
+				KinkyDungeonPrisonExtraGhostRep += 2;
 				KinkyDungeonJailGuard.CurrentAction = "jailWander";
 				KinkyDungeonJailGuard.gx = KinkyDungeonJailGuard.x;
 				KinkyDungeonJailGuard.gy = KinkyDungeonJailGuard.y;
@@ -1996,7 +1998,8 @@ function KinkyDungeonHandleJailSpawns() {
 						KinkyDungeonPrisonReduction += 1;
 						KinkyDungeonChangeRep("Prisoner", -1);
 					}
-					KinkyDungeonChangeRep("Ghost", 1);
+					KinkyDungeonChangeRep("Ghost", 1 + KinkyDungeonPrisonExtraGhostRep);
+					KinkyDungeonPrisonExtraGhostRep = 0;
 				}
 			}
 		}

--- a/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonRestraints.js
+++ b/BondageClub/Screens/MiniGame/KinkyDungeon/KinkyDungeonRestraints.js
@@ -401,6 +401,15 @@ function KinkyDungeonHasGhostHelp() {
 	return (KinkyDungeonTargetTile && KinkyDungeonTargetTile.Type == "Ghost" && KinkyDungeonGhostDecision <= 1);
 }
 
+function KinkyDungeonIsWearingLeash() {
+	for (let restraint of KinkyDungeonRestraintList()) {
+		if (restraint.restraint && restraint.restraint.leash) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function KinkyDungeonIsHandsBound(ApplyGhost) {
 	return (!ApplyGhost || !KinkyDungeonHasGhostHelp()) &&
 		(InventoryItemHasEffect(InventoryGet(KinkyDungeonPlayer, "ItemHands"), "Block", true) || InventoryGroupIsBlockedForCharacter(KinkyDungeonPlayer, "ItemHands"));


### PR DESCRIPTION
When idling, guards now have a 3% chance of deciding to take the player character on a trip.

Not a big fan of the leash code used in this, it's basically a custom, weaker port of the leash code already used for the global enemy grabs. But, well, it seems to work as expected including in edge cases.